### PR TITLE
Fix whitespace top pages

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,8 +10,12 @@
   <%#= stylesheet_pack_tag 'application', media: 'all' %> <!-- Uncomment if you import CSS in app/javascript/packs/application.js -->
 </head>
 <body>
-  <p class="notice"><%= notice %></p>
-  <p class="alert"><%= alert %></p>
+  <% unless notice.nil? %>
+    <p class="notice"><%= notice %></p>
+  <% end %>
+  <% unless alert.nil? %>
+   <p class="alert"><%= alert %></p>
+  <% end %>
   <%= yield %>
   <%= javascript_include_tag 'application' %>
   <%= javascript_pack_tag 'application' %>


### PR DESCRIPTION
Devise had an issue where you had a constant white bar at the top of your page. It was fixed by creating a conditional statement what only shows the element if it has that information.

This might be handy for hidden elements in the future.